### PR TITLE
Support unmanaged secrets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "secrets" {
   default     = []
 }
 
+variable "unmanaged" {
+  description = "terraform must ignore secrets lifecycle"
+  default     = false
+}
+
 variable "automatically_after_days" {
   description = "Specifies the number of days between automatic scheduled rotations of the secret."
   type        = number


### PR DESCRIPTION
First thank you for this module, it is quite great!

I have use cases, where I need to prepare some AWS secrets, but I can't
have them set randomly or stored inside a shared file.

So I'm looking for a way to be able to enable `lifecycle` when I have such
use case. Unfortunately `dynamic` does not support `lifecycle` so this
is the solution I ended with.

In case of shared states, this would allow the secret to be initalized,
eventually with real secret values through `terraform.tfvars`, by a
first user, but would not prevent another user that don't have access
to the secrets to use the state.

```
module "secrets-manager-2" {

  source = "lgallard/secrets-manager/aws"

  secrets = [
   {
      name                    = "unmanaged-secret-kv-1"
      description             = "This is a key/value secret"
      secret_string           = "Changeme"
      recovery_window_in_days = 7
    },
  ]

  unmanaged = true

  tags = {
    Owner       = "DevOps team"
    Environment = "dev"
    Terraform   = true
  }

}
```