### PR TITLE
Support Unmanaged Rotation Secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,13 @@ resource "aws_secretsmanager_secret_version" "rsm-svu" {
   secret_string = lookup(element(local.rotate_secrets, count.index), "secret_string")
   secret_binary = lookup(element(local.rotate_secrets, count.index), "secret_binary") != null ? base64encode(lookup(element(local.rotate_secrets, count.index), "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.rsm]
+
+  lifecycle {
+    ignore_changes = [
+      secret_string,
+      secret_binary,
+    ]
+  }
 }
 
 resource "aws_secretsmanager_secret_rotation" "rsm-sr" {


### PR DESCRIPTION
Extends behavior added in PR #4 to rotating secrets (https://github.com/lgallard/terraform-aws-secrets-manager/pull/4).

For our use case, this module sets up our rotated secret based off an initial password set by a Terraform variable.  The secret then immediately rotates to no longer match the initial password which is exposed in the Terraform state file. From here, Secrets Manager handles the rotation schedule, and we do not want the secret to be updated by subsequent runs of our terraform modules that still prompt for and and apply a new password.  

Ignoring changes to the rotated secrets_string and secrets_binary will prevent subsequent terraform applies from changing the secret currently in rotation.  