### PR TITLE
Add support for unmanaged rotated secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0 (December 1, 2020)
+
+ENHANCEMENTS:
+
+  * Add support for unmanaged rotated secrets:  Avoid rotation of secrets by subsequent runs of Terraform
+
+Thanks @moliver-aicradle
+
 ## 0.3.0 (October 22, 2020)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ module "secrets-manager-5" {
 | rotate\_secrets | List of secrets to keep and rotate in AWS Secrets Manager | `any` | `[]` | no |
 | secrets | List of secrets to keep in AWS Secrets Manager | `any` | `[]` | no |
 | tags | Specifies a key-value map of user-defined tags that are attached to the secret. | `any` | `{}` | no |
-| unmanaged | Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, thus, avoiding other users to change the secrets | `bool` | `false` | no |
+| unmanaged | Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, thus, avoiding other users to change the secretsor the rotation of secrets by subsequent runs of Terraform | `bool` | `false` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "secrets" {
 }
 
 variable "unmanaged" {
-  description = "Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, thus, avoiding other users to change the secrets"
+  description = "Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, thus, avoiding other users to change the secretsor the rotation of secrets by subsequent runs of Terraform"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## 0.4.0 (December 1, 2020)

ENHANCEMENTS:

  * Add support for unmanaged rotated secrets:  Avoid rotation of secrets by subsequent runs of Terraform

Thanks @moliver-aicradle (PR #6)
