### PR TITLE
Add lifecycle ignore for `secret_id` in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FIXES:
 
-  * Add lifecycle ignore for `secret_id`
+  * Add lifecycle ignore for `secret_id` (thanks @jmonte-sph)
 
 ## 0.6.1 (October 19, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.2 (January 11, 2023)
+
+FIXES:
+
+  * Add lifecycle ignore for `secret_id`
+
 ## 0.6.1 (October 19, 2022)
 
 FIXES:

--- a/main.tf
+++ b/main.tf
@@ -94,8 +94,8 @@ resource "aws_secretsmanager_secret_rotation" "rsm-sr" {
   rotation_rules {
     automatically_after_days = lookup(each.value, "automatically_after_days", var.automatically_after_days)
   }
-  depends_on    = [aws_secretsmanager_secret.rsm]
-  
+  depends_on = [aws_secretsmanager_secret.rsm]
+
   lifecycle {
     ignore_changes = [
       secret_id,


### PR DESCRIPTION
# 0.6.2 (January 11, 2023)

FIXES:

  * Add lifecycle ignore for `secret_id` (thanks @jmonte-sph)