### PR TITLE
allow and empty replica region kms_key_id and use the default.

### DIFF
--- a/examples/replication/README.md
+++ b/examples/replication/README.md
@@ -1,45 +1,51 @@
 # Plain text example
 ```
-module "secrets-manager-1" {
+module "secrets-manager-6" {
 
-  #source = "lgallard/secrets-manager/aws"
-  source = "../../"
+  source = "lgallard/secrets-manager/aws"
 
   secrets = {
-    secret-1 = {
-      description             = "My secret 1"
+    secret-plain = {
+      description             = "My plain text secret"
       recovery_window_in_days = 7
       secret_string           = "This is an example"
-      policy                  = <<POLICY
-				{
-					"Version": "2012-10-17",
-					"Statement": [
-						{
-							"Sid": "EnableAllPermissions",
-							"Effect": "Allow",
-							"Principal": {
-								"AWS": "*"
-							},
-							"Action": "secretsmanager:GetSecretValue",
-							"Resource": "*"
-						}
-					]
-				}
-				POLICY
+      replica_regions = {
+        us-west-2 = "arn:aws:kms:us-west-2:1234567890:key/12345678-1234-1234-1234-123456789012"
+      }
+      force_overwrite_replica_secret = true
     },
-    secret-2 = {
-      description             = "My secret 2"
+    secret-key-value = {
+      description = "This is a key/value secret"
+      secret_key_value = {
+        username = "user"
+        password = "topsecret"
+      }
+      replica_regions = {
+        us-west-1 = "arn:aws:kms:us-west-1:1234567890:key/12345678-1234-1234-1234-123456789012"
+      }
+      force_overwrite_replica_secret = false
+      tags = {
+        app = "web"
+      }
       recovery_window_in_days = 7
-      secret_string           = "This is another example"
-      policy                  = null
-    }
+    },
   }
 
   tags = {
     Owner       = "DevOps team"
     Environment = "dev"
     Terraform   = true
-
   }
+
 }
+```
+
+NOTE: If you leave the replica_regions with an empty map it will use the default KMS key for that region.
+```
+    replica_regions = {
+      us-west-2 = {}
+      us-west-1 = "arn:aws:kms:us-west-1:1234567890:key/12345678-1234-1234-1234-123456789012"
+
+    }
+
 ```

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ resource "aws_secretsmanager_secret" "sm" {
   dynamic "replica" {
     for_each = lookup(each.value, "replica_regions", {})
     content {
-      region     = replica.key
-      kms_key_id = replica.value
+      region     = try(replica.value.region, replica.key)
+      kms_key_id = try(replica.value.kms_key_id, null)      
     }
   }
 }


### PR DESCRIPTION
Allow no kms_key_id to be specified in replica_regions which uses the default KMS key for the specified region. 
Updated example to actually show an example of setting up a replica. 