### PR TITLE
Allow 'Name' parameter to overwrite each.key as Secret Name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "sm" {
   for_each                       = var.secrets
-  name                           = lookup(each.value, "name_prefix", null) == null ? each.key : null
+  name                           = lookup(each.value, "name_prefix", null) == null && lookup(each.value, "name", null) == null ? each.key : (lookup(each.value, "name_prefix", null) == null && lookup(each.value, "name", null) != null ? each.value.name : null)
   name_prefix                    = lookup(each.value, "name_prefix", null) != null ? lookup(each.value, "name_prefix") : null
   description                    = lookup(each.value, "description", null)
   kms_key_id                     = lookup(each.value, "kms_key_id", null)
@@ -49,7 +49,7 @@ resource "aws_secretsmanager_secret_version" "sm-svu" {
 # Rotate secrets
 resource "aws_secretsmanager_secret" "rsm" {
   for_each                       = var.rotate_secrets
-  name                           = lookup(each.value, "name_prefix", null) == null ? each.key : null
+  name                           = lookup(each.value, "name_prefix", null) == null && lookup(each.value, "name", null) == null ? each.key : (lookup(each.value, "name_prefix", null) == null && lookup(each.value, "name", null) != null ? each.value.name : null)
   name_prefix                    = lookup(each.value, "name_prefix", null) != null ? lookup(each.value, "name_prefix") : null
   description                    = lookup(each.value, "description")
   kms_key_id                     = lookup(each.value, "kms_key_id", null)


### PR DESCRIPTION
Currently, a 'name' parameter can be supplied, but which has no effect on the name of the secret. The parameter 'name_prefix' can be supplied, which will overwrite the key as the name of the secret, but doing so will also generate a unique key name after your specified prefix.

This change aims to add some extra logic to the checks done to the 'name' parameter, which will allow the secret name to be specified if so desired. 
The use-case for this is one I came across recently, in which a for_each argument is used within the secrets/rotate_secrets parameter, and results in the key being unable to be changed due to the following error:

> │ Error: Invalid for_each argument
> │ 
> │   on .terraform/modules/secrets/main.tf line 50, in resource "aws_secretsmanager_secret" "rsm":
> │   50:   for_each                = var.rotate_secrets
> │     ├────────────────
> │     │ var.rotate_secrets will be known only after apply
> │ 
> │ The "for_each" map includes keys derived from resource attributes that
> │ cannot be determined until apply, and so Terraform cannot determine the
> │ full set of keys that will identify the instances of this resource.
> │ 
> │ When working with unknown values in for_each, it's better to define the map
> │ keys statically in your configuration and place apply-time results only in
> │ the map values.
> │ 
> │ Alternatively, you could use the -target planning option to first apply
> │ only the resources that the for_each value depends on, and then apply a
> │ second time to fully converge.

This change shouldn't cause any clashes with the current functionality, as it still prioritises checking that 'name_prefix' == null before setting the value to `each.value.name` 