### PR TITLE
fix: not defined index in context

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,14 +12,14 @@ resource "aws_secretsmanager_secret" "sm" {
     for_each = lookup(each.value, "replica_regions", {})
     content {
       region     = try(replica.value.region, replica.key)
-      kms_key_id = try(replica.value.kms_key_id, null)      
+      kms_key_id = try(replica.value.kms_key_id, null)
     }
   }
 }
 
 resource "aws_secretsmanager_secret_version" "sm-sv" {
   for_each      = { for k, v in var.secrets : k => v if !var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.sm[index].arn
+  secret_id     = aws_secretsmanager_secret.sm[each.key].arn
   secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string", null) : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
   secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.sm]
@@ -32,7 +32,7 @@ resource "aws_secretsmanager_secret_version" "sm-sv" {
 
 resource "aws_secretsmanager_secret_version" "sm-svu" {
   for_each      = { for k, v in var.secrets : k => v if var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.sm[index].arn
+  secret_id     = aws_secretsmanager_secret.sm[each.key].arn
   secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
   secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.sm]
@@ -61,7 +61,7 @@ resource "aws_secretsmanager_secret" "rsm" {
 
 resource "aws_secretsmanager_secret_version" "rsm-sv" {
   for_each      = { for k, v in var.rotate_secrets : k => v if !var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.rsm[index].arn
+  secret_id     = aws_secretsmanager_secret.rsm[each.key].arn
   secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
   secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.rsm]
@@ -74,7 +74,7 @@ resource "aws_secretsmanager_secret_version" "rsm-sv" {
 
 resource "aws_secretsmanager_secret_version" "rsm-svu" {
   for_each      = { for k, v in var.rotate_secrets : k => v if var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.rsm[index].arn
+  secret_id     = aws_secretsmanager_secret.rsm[each.key].arn
   secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
   secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.rsm]
@@ -90,7 +90,7 @@ resource "aws_secretsmanager_secret_version" "rsm-svu" {
 
 resource "aws_secretsmanager_secret_rotation" "rsm-sr" {
   for_each            = var.rotate_secrets
-  secret_id           = aws_secretsmanager_secret.rsm[index].arn
+  secret_id           = aws_secretsmanager_secret.rsm[each.key].arn
   rotation_lambda_arn = lookup(each.value, "rotation_lambda_arn")
 
   rotation_rules {


### PR DESCRIPTION
Probably something changed between Terraform versions that deprecated the usage of `index` in `for_each` block as reported in #42, therefore several errors showed up in module version `0.10.0`:

```
│ Error: Invalid reference
│
│ on .terraform/modules/secrets-manager/main.tf line 22, in resource "aws_secretsmanager_secret_version" "sm-sv":
│ 22: secret_id = aws_secretsmanager_secret.sm[index].arn
│
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
╵
```


This fixes #42 