### PR TITLE
Allow to use `version_stages` on secret versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,12 @@ resource "aws_secretsmanager_secret" "sm" {
 }
 
 resource "aws_secretsmanager_secret_version" "sm-sv" {
-  for_each      = { for k, v in var.secrets : k => v if !var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.sm[each.key].arn
-  secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string", null) : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
-  secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
-  depends_on    = [aws_secretsmanager_secret.sm]
+  for_each       = { for k, v in var.secrets : k => v if !var.unmanaged }
+  secret_id      = aws_secretsmanager_secret.sm[each.key].arn
+  secret_string  = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string", null) : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
+  secret_binary  = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
+  version_stages = var.version_stages
+  depends_on     = [aws_secretsmanager_secret.sm]
   lifecycle {
     ignore_changes = [
       secret_id,
@@ -31,11 +32,12 @@ resource "aws_secretsmanager_secret_version" "sm-sv" {
 }
 
 resource "aws_secretsmanager_secret_version" "sm-svu" {
-  for_each      = { for k, v in var.secrets : k => v if var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.sm[each.key].arn
-  secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
-  secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
-  depends_on    = [aws_secretsmanager_secret.sm]
+  for_each       = { for k, v in var.secrets : k => v if var.unmanaged }
+  secret_id      = aws_secretsmanager_secret.sm[each.key].arn
+  secret_string  = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
+  secret_binary  = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
+  version_stages = var.version_stages
+  depends_on     = [aws_secretsmanager_secret.sm]
 
   lifecycle {
     ignore_changes = [
@@ -60,11 +62,12 @@ resource "aws_secretsmanager_secret" "rsm" {
 }
 
 resource "aws_secretsmanager_secret_version" "rsm-sv" {
-  for_each      = { for k, v in var.rotate_secrets : k => v if !var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.rsm[each.key].arn
-  secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
-  secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
-  depends_on    = [aws_secretsmanager_secret.rsm]
+  for_each       = { for k, v in var.rotate_secrets : k => v if !var.unmanaged }
+  secret_id      = aws_secretsmanager_secret.rsm[each.key].arn
+  secret_string  = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
+  secret_binary  = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
+  version_stages = var.version_stages
+  depends_on     = [aws_secretsmanager_secret.rsm]
   lifecycle {
     ignore_changes = [
       secret_id,
@@ -73,11 +76,12 @@ resource "aws_secretsmanager_secret_version" "rsm-sv" {
 }
 
 resource "aws_secretsmanager_secret_version" "rsm-svu" {
-  for_each      = { for k, v in var.rotate_secrets : k => v if var.unmanaged }
-  secret_id     = aws_secretsmanager_secret.rsm[each.key].arn
-  secret_string = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
-  secret_binary = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
-  depends_on    = [aws_secretsmanager_secret.rsm]
+  for_each       = { for k, v in var.rotate_secrets : k => v if var.unmanaged }
+  secret_id      = aws_secretsmanager_secret.rsm[each.key].arn
+  secret_string  = lookup(each.value, "secret_string", null) != null ? lookup(each.value, "secret_string") : (lookup(each.value, "secret_key_value", null) != null ? jsonencode(lookup(each.value, "secret_key_value", {})) : null)
+  secret_binary  = lookup(each.value, "secret_binary", null) != null ? base64encode(lookup(each.value, "secret_binary")) : null
+  version_stages = var.version_stages
+  depends_on     = [aws_secretsmanager_secret.rsm]
 
   lifecycle {
     ignore_changes = [

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "automatically_after_days" {
   default     = 30
 }
 
+variable "version_stages" {
+  description = "List of version stages to be handled. Kept as null for backwards compatibility."
+  type        = list(string)
+  default     = null
+}
+
 # Tags
 variable "tags" {
   description = "Specifies a key-value map of user-defined tags that are attached to the secret."


### PR DESCRIPTION
There is a corner-case problem which might cause data loss: if secret content is changed via `secret_string` or `secret_binary`, it will override the previous value. See https://github.com/hashicorp/terraform-provider-aws/issues/25168

According to [the comment](https://github.com/hashicorp/terraform-provider-aws/issues/25168#issuecomment-1174371944), it is possible to avoid that situation by using the `version_stages` parameter which is not supported by this module. And that is the situation this PR is trying to fix: to allow specifying it.

Sadly, it seems that using it by default might cause data loss as well... So I had to leave the default `null` value, but at least this patch allows to document the patch and to keep the secret data even if the content changes on terraform, if desired.