### PR TITLE
Release 0.11.0: Allow to use version_stages on secret versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.0 (December 19, 2023)
+
+ENHANCEMENTS:
+
+* Allow to use ´version_stages´ on secret versions (thanks @magmax)
+
 ## 0.10.1 (October 29, 2023)
 
 FIXES:

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ No modules.
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets to keep in AWS Secrets Manager | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Specifies a key-value map of user-defined tags that are attached to the secret. | `any` | `{}` | no |
 | <a name="input_unmanaged"></a> [unmanaged](#input\_unmanaged) | Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, thus, avoiding other users to change or rotate the secrets by subsequent runs of Terraform | `bool` | `false` | no |
+| <a name="input_version_stages"></a> [version\_stages](#input\_version\_stages) | List of version stages to be handled. Kept as null for backwards compatibility. | `list(string)` | `null` | no |
 
 ## Outputs
 


### PR DESCRIPTION
## 0.11.0 (December 19, 2023)

ENHANCEMENTS:

* Allow to use `version_stages` on secret versions (thanks @magmax)