### PR TITLE
Fix: Terraform version syntax

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,10 @@
 terraform {
+  required_version = ">= v0.13.7"
 
   required_providers {
-    aws = ">= 2.67.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.67.0"
+    }
   }
 }


### PR DESCRIPTION
## 0.11.2 (June 3, 2024)

FIX:

* Terraform version requirements syntax