### PR TITLE
Fix Terraform version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FIX:
 
-* Fix required constriants
+* Fix required constraints
 * Remove Dependabot
 
 ## 0.11.3 (June 3, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FIX:
 
-* Fix required constrians
+* Fix required constriants
 * Remove Dependabot
 
 ## 0.11.3 (June 3, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.11.4 (June 3, 2024)
+
+FIX:
+
+* Fix required constrians
+* Remove Dependabot
+
 ## 0.11.3 (June 3, 2024)
 
 FIX:

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> v0.13.7"
+  required_version = ">= v0.13.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.67.0"
+      version = ">= 2.67.0"
     }
   }
 }


### PR DESCRIPTION
## 0.11.4 (June 3, 2024)

FIX:

* Fix required constraints
* Remove Dependabot

It fixes #54 