### PR TITLE
docs: fix dynamic block syntax error in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,10 +440,11 @@ resource "aws_secretsmanager_secret_replica" "this" {
   secret_id = aws_secretsmanager_secret.this[each.value.secret_name].id
   region    = each.value.region
   
-  dynamic "kms_key_id" {
-    for_each = each.value.kms_key_id != null ? [1] : []
+  dynamic "replica" {
+    for_each = lookup(each.value, "replica_regions", {})
     content {
-      kms_key_id = each.value.kms_key_id
+      region     = try(replica.value.region, replica.key)
+      kms_key_id = try(replica.value.kms_key_id, null)
     }
   }
 }


### PR DESCRIPTION
This PR fixes the dynamic block syntax error reported in issue #93.

## Changes
- Replace invalid `dynamic "kms_key_id"` syntax with correct `dynamic "replica"`
- Update content structure to match actual implementation in main.tf
- Ensure documentation reflects working Terraform code

Fixes #93

Generated with [Claude Code](https://claude.ai/code)