### PR TITLE
fix: grant commit permissions to claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write # Enable git commit and push operations
+      pull-requests: write # Enable PR updates and comments
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
This PR adds write permissions to the Claude GitHub Action workflow to enable automated commits and PR updates.

## Changes
- **Add `contents: write`** - Enables git commit and push operations
- **Add `pull-requests: write`** - Enables PR updates and comments  
- Maintains security by keeping permissions scoped to necessary operations only

## Purpose
- Allows Claude to commit code improvements directly when addressing review feedback
- Enables automated responses to code review suggestions
- Improves developer workflow by reducing manual commit overhead

## Security Considerations
- Permissions are scoped specifically to required operations
- Write access is limited to contents and pull requests
- Follows GitHub security best practices for action permissions

## Test Plan
- [x] Permissions updated in workflow file
- [x] Cherry-picked from working implementation 
- [ ] Test Claude's ability to commit after merge

## Next Steps
Once merged, this will enable the Claude action to make commits on PR #108 and future PRs.