### PR TITLE
fix: skip CI/CD tests for documentation-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,22 @@ name: Test
 on:
   push:
     branches: [ master, main ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
   pull_request:
     branches: [ master, main ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
 
 env:
   TERRAFORM_VERSION: latest


### PR DESCRIPTION
## Summary
This PR addresses issue #117 by adding path filters to the CI/CD workflow to skip tests when only documentation files are modified.

## Changes
- Added `paths-ignore` configuration to both push and pull_request triggers in `.github/workflows/test.yml`
- Tests will now be skipped for changes to:
  - Markdown files (`**.md`)
  - LICENSE file
  - `.gitignore`
  - Documentation directory (`docs/**`)
  - GitHub issue and PR templates

## Benefits
- Reduces unnecessary CI/CD runs for documentation changes
- Saves compute resources and time
- Provides faster feedback for documentation PRs
- Aligns with CI/CD best practices

## Test Plan
- [x] Modified workflow file with path filters
- [ ] Verify that documentation-only PRs skip tests
- [ ] Verify that code changes still trigger tests

Fixes #117
