### PR TITLE
feat: add MCP server support for enhanced documentation access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,30 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          # MCP Configuration for Terraform and Context7 documentation access
+          mcp_config: |
+            {
+              "mcpServers": {
+                "terraform": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-terraform@latest"
+                  ]
+                },
+                "context7": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@upstash/context7-mcp@latest"
+                  ]
+                }
+              }
+            }
+
+          # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
@@ -49,9 +73,6 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
           
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
@@ -61,4 +82,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,3 +848,83 @@ terraform {
 ```
 
 *Note: Version constraints should be chosen based on actual requirements and compatibility needs.*
+
+## MCP Server Configuration
+
+### Available MCP Servers
+This project is configured to use the following Model Context Protocol (MCP) servers for enhanced documentation access:
+
+#### Terraform MCP Server
+**Purpose**: Access up-to-date Terraform and AWS provider documentation
+**Package**: `@modelcontextprotocol/server-terraform`
+
+**Local Configuration** (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "terraform": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-terraform@latest"]
+    }
+  }
+}
+```
+
+**Usage Examples**:
+- `Look up aws_secretsmanager_secret resource documentation`
+- `Find the latest Secrets Manager rotation examples`
+- `Search for AWS Secrets Manager Terraform modules`
+- `Get documentation for aws_secretsmanager_secret_version resource`
+
+#### Context7 MCP Server
+**Purpose**: Access general library and framework documentation
+**Package**: `@upstash/context7-mcp`
+
+**Local Configuration** (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+
+**Usage Examples**:
+- `Look up Go testing patterns for Terratest`
+- `Find AWS CLI Secrets Manager commands documentation`
+- `Get current Terraform best practices for sensitive data`
+- `Search for GitHub Actions workflow patterns`
+
+### GitHub Actions Integration
+The MCP servers are automatically available in GitHub Actions through the claude.yml workflow configuration. Claude can access the same documentation in PRs and issues as available locally.
+
+### Usage Tips
+1. **Be Specific**: When requesting documentation, specify the exact resource or concept
+2. **Version Awareness**: Both servers provide current, version-specific documentation
+3. **Combine Sources**: Use Terraform MCP for Secrets Manager-specific docs, Context7 for general development patterns
+4. **Local vs CI**: Same MCP servers work in both local development and GitHub Actions
+
+### Example Workflows
+
+**Secrets Manager Resource Development**:
+```
+@claude I need to add support for cross-region secret replication. Can you look up the latest aws_secretsmanager_secret_replica documentation and show me how to implement this feature?
+```
+
+**Testing Pattern Research**:
+```
+@claude Look up current Terratest patterns for testing Secrets Manager resources and help me add comprehensive tests for the secret rotation feature.
+```
+
+**Security Enhancement**:
+```
+@claude Research the latest Secrets Manager security best practices and help me implement enhanced encryption configurations in this module.
+```
+
+**Ephemeral Mode Development**:
+```
+@claude Look up the latest Terraform ephemeral resource patterns and help me improve the write-only secret handling in this module.
+```


### PR DESCRIPTION
## Summary

Add Model Context Protocol (MCP) server configuration to enable enhanced documentation access in GitHub Actions and local development environments.

- Add Terraform MCP server (@modelcontextprotocol/server-terraform) for AWS provider documentation
- Add Context7 MCP server (@upstash/context7-mcp) for general library documentation  
- Update claude.yml workflow with MCP configuration and allowed tools
- Add comprehensive MCP documentation section to CLAUDE.md with Secrets Manager-specific examples

## Test plan

- [ ] Validate GitHub Actions workflow syntax
- [ ] Test MCP server functionality in GitHub Actions environment
- [ ] Verify documentation examples work as expected
- [ ] Confirm no breaking changes to existing workflow behavior