### PR TITLE
chore: configure Renovate to prevent pre-release Go versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,18 @@
       "matchPackageNames": [
         "/^hashicorp/terraform$/"
       ]
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "ignoreUnstable": true,
+      "enabled": true
+    },
+    {
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["actions/setup-go"],
+      "extractVersion": "^v(?<version>.*)$",
+      "versioning": "go-mod-directive",
+      "ignoreUnstable": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Added Renovate configuration to prevent future pre-release Go version suggestions
- This is a preventive measure to avoid issues with non-stable Go versions

## Changes
- Enhanced `renovate.json` with rules to:
  - Ignore unstable golang-version datasource releases
  - Prevent unstable versions for actions/setup-go action

## Note
This repository's GitHub Actions workflows already use Go 1.21, which is stable. This change is preventive to ensure Renovate doesn't suggest pre-release versions in the future.

## Test Plan
- [ ] Renovate will no longer suggest pre-release Go versions
- [ ] Existing stable Go version (1.21) continues to work