### PR TITLE
ci: release Terraform refactors as patch changes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,25 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        }
+      ]
     }
   },
   "pull-request-title-pattern": "chore: release ${version}"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -19,6 +19,10 @@
           "section": "Performance Improvements"
         },
         {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
           "type": "refactor",
           "section": "Code Refactoring"
         }


### PR DESCRIPTION
## Summary
- Configure release-please changelog sections explicitly for Terraform module releases.
- Include `refactor:` commits under **Code Refactoring** so implementation refactors can produce normal patch releases.
- Keep `feat:`, `fix:`, `perf:`, and `revert:` visible; keep docs/CI/chore/test/style/build changes hidden unless they are intentionally made release-visible later.

## Policy
Terraform module implementation is the distributed artifact. Future module implementation refactors should keep using honest `refactor:` commit types; release-please will now include those in release PRs instead of requiring maintainers to mislabel them as `fix:`.

## Verification
- `python3 -m json.tool .release-please-config.json`
- `pnpm dlx release-please release-pr --repo-url=lgallard/terraform-aws-secrets-manager --target-branch=master --config-file=.release-please-config.json --manifest-file=.release-please-manifest.json --dry-run`
- Synthetic release-please `filterCommits` check confirmed `refactor`, `revert`, and `fix` are visible while `docs` and `ci` remain hidden.
- `terraform fmt -check -recursive`
- `SKIP=detect-aws-credentials pre-commit run --files .release-please-config.json`
- `git diff --check`

Closes #164
