### PR TITLE
ci: skip validation for release-please releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,15 @@ env:
 jobs:
   validate:
     name: Validate
+    if: >-
+      ${{
+        !(
+          (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release ')) ||
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.user.login == 'github-actions[bot]' &&
+            startsWith(github.event.pull_request.title, 'chore: release '))
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Skip the `Validate` job for release-please release PRs created by `github-actions[bot]`.
- Skip the `Validate` job for release merge commits whose head commit message starts with `chore: release `.
- Keep normal validation active for regular PRs and pushes.

Closes #134

## Test Plan
- `python3` YAML parse for `.github/workflows/test.yml`
- `SKIP=detect-aws-credentials pre-commit run --files .github/workflows/test.yml`
- `git diff --check`

## Notes
- Local `pre-commit run --files .github/workflows/test.yml` without `SKIP=detect-aws-credentials` fails because no AWS credential files are configured locally; the CI workflow already skips that hook.
