### PR TITLE
feat!: require AWS provider >= 6.50.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,10 @@ rotate_secrets = {
 }
 ```
 
+### Provider Compatibility Policy
+
+Ephemeral/write-only secret version support uses `aws_secretsmanager_secret_version.secret_string_wo` and `secret_string_wo_version`. Keep the module AWS provider constraint at `>= 6.50.0` unless a future issue deliberately revisits the policy. Provider 6.50.0 is the stability-first minimum because it includes fixes for final-plan consistency, eventual consistency on secret-version creation/read-after-create, empty `version_stages`, and switching between `secret_string` and `secret_string_wo` without unnecessary replacement.
+
 ### Version Management
 
 #### Version Control for Updates
@@ -397,7 +401,7 @@ resource "aws_secretsmanager_secret_version" "db_secret_versions" {
 
 #### Version Requirements
 - **Terraform**: >= 1.11 (for ephemeral resource support)
-- **AWS Provider**: >= 2.67.0
+- **AWS Provider**: >= 6.50.0
 - **Module**: Latest version with ephemeral support
 
 #### Backward Compatibility

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ AWS Secrets Manager helps you protect secrets needed to access your applications
 - ✅ **Resource Policies**: Attach custom IAM policies to secrets
 - ✅ **Flexible Secret Types**: Support for plain text, key/value pairs, and binary secrets
 
+## Compatibility
+
+| Component | Minimum version | Notes |
+|-----------|-----------------|-------|
+| Terraform | `>= 1.11.0` | Required for ephemeral resources and write-only arguments. |
+| AWS provider | `>= 6.50.0` | Required so the module can use `aws_secretsmanager_secret_version.secret_string_wo` / `secret_string_wo_version` safely. Version 6.50.0 includes Secrets Manager fixes for final-plan consistency, creation eventual consistency, empty `version_stages`, and switching between `secret_string` and `secret_string_wo`. |
+
+The module declares the AWS provider minimum at the root, so all usage modes use the same compatibility policy. Ephemeral mode additionally requires setting `secret_string_wo_version >= 1` for every managed secret value.
+
 ## Examples
 
 Check the [examples](/examples/) folder where you can see the complete compilation of snippets.
@@ -548,13 +557,13 @@ Successfully moved 1 object(s).
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/binary/main.tf
+++ b/examples/binary/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/ephemeral/README.md
+++ b/examples/ephemeral/README.md
@@ -42,7 +42,9 @@ When using ephemeral secrets, you can control when secrets are updated by increm
 ## Requirements
 
 - Terraform >= 1.11
-- AWS Provider >= 2.67.0
+- AWS Provider >= 6.50.0
+
+The AWS provider minimum is intentionally stability-first: provider 6.50.0 includes `aws_secretsmanager_secret_version` fixes for write-only secret values, including final-plan consistency, eventual consistency during creation/read-after-create, empty `version_stages`, and switching between `secret_string` and `secret_string_wo` without unnecessary replacement.
 
 ## Benefits
 

--- a/examples/ephemeral/ephemeral-for-each-patterns.md
+++ b/examples/ephemeral/ephemeral-for-each-patterns.md
@@ -237,7 +237,7 @@ All solutions properly prevent sensitive data from being stored in Terraform sta
 **For the user who reported this issue:**
 
 1. **Use Solution 1 (Direct Resources)** - Provides exactly the functionality you want
-2. **Update to module version 0.16.0+** when released (includes version fix)
+2. **Use module version 0.16.0+** for ephemeral password support
 3. **Ensure Terraform >= 1.11.0** for ephemeral resource support
 
 **Benefits of Direct Resources approach:**
@@ -250,7 +250,7 @@ All solutions properly prevent sensitive data from being stored in Terraform sta
 ## Version Requirements
 
 - **Terraform**: `>= 1.11.0` (for ephemeral resources)
-- **AWS Provider**: `>= 2.67.0`
-- **Module**: `>= 0.16.0` (when released with fixes)
+- **AWS Provider**: `>= 6.50.0`
+- **Module**: `>= 0.16.0`
 
 The ephemeral password functionality the user requested is **fully achievable** with the direct resources approach, providing the same security benefits while working within Terraform's architectural constraints.

--- a/examples/ephemeral/ephemeral-limitations.md
+++ b/examples/ephemeral/ephemeral-limitations.md
@@ -228,8 +228,8 @@ If you're currently using the pattern that doesn't work:
 ## Version Requirements
 
 - **Terraform**: >= 1.11.0 (for ephemeral resources and write-only arguments)
-- **AWS Provider**: >= 2.67.0
-- **Module**: >= 0.16.0 (when released with ephemeral fixes)
+- **AWS Provider**: >= 6.50.0
+- **Module**: >= 0.16.0
 
 ## State Security
 

--- a/examples/ephemeral/provider.tf
+++ b/examples/ephemeral/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/key-value/main.tf
+++ b/examples/key-value/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/plaintext/main.tf
+++ b/examples/plaintext/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/replication/main.tf
+++ b/examples/replication/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/rotation/main.tf
+++ b/examples/rotation/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.50.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- require `hashicorp/aws >= 6.50.0` at the module root and in examples
- document the stability-first provider policy for write-only secret version support
- update stale ephemeral docs that advertised older AWS provider minimums

## Source notes
- Terraform Registry reports latest `hashicorp/aws` as 6.53.0.
- The exact-tag provider docs for `aws_secretsmanager_secret_version` confirm `secret_string_wo` and `secret_string_wo_version` in v6.53.0.
- The v6.50.0 provider changelog includes Secrets Manager fixes for final-plan consistency, creation/read-after-create eventual consistency, empty `version_stages`, and switching between `secret_string` and `secret_string_wo` without unnecessary replacement.

## Issue #112 review
- Issue #112 remains open for ephemeral CI test failures.
- This PR addresses the provider-policy prerequisite by selecting the stability-first `>= 6.50.0` minimum; there are no `test/terraform_ephemeral_test.go` files in the current tree to re-enable or run here.

## Validation
- `terraform init -backend=false`
- `terraform -chdir=examples/plaintext init -backend=false`
- `terraform -chdir=examples/key-value init -backend=false`
- `terraform -chdir=examples/replication init -backend=false`
- `terraform -chdir=examples/binary init -backend=false`
- `terraform -chdir=examples/rotation init -backend=false`
- `terraform -chdir=examples/ephemeral init -backend=false`
- `pre-commit run --files CLAUDE.md README.md examples/binary/main.tf examples/ephemeral/README.md examples/ephemeral/ephemeral-for-each-patterns.md examples/ephemeral/ephemeral-limitations.md examples/ephemeral/provider.tf examples/key-value/main.tf examples/plaintext/main.tf examples/replication/main.tf examples/rotation/main.tf versions.tf`
- `terraform fmt -check -recursive`
- `terraform validate`
- `terraform -chdir=examples/plaintext validate`
- `terraform -chdir=examples/key-value validate`
- `terraform -chdir=examples/replication validate`
- `terraform -chdir=examples/binary validate`
- `terraform -chdir=examples/rotation validate`
- `terraform -chdir=examples/ephemeral validate`
- `git diff --check`

Closes #177
Related #112
