### PR TITLE
fix: remove replica policy propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ module "secrets-manager-replication" {
 }
 ```
 
-#### Replicating the resource policy
+#### Resource policies on replicated secrets
 
-AWS Secrets Manager replication copies the secret value to replica regions, but **not** the resource policy. Set `replicate_policy = true` on a regular or rotating secret to have the module apply the secret's `policy` in every replica region as well — updates to the policy on the source secret then propagate to all replicas on the next apply:
+[AWS Secrets Manager replication](https://docs.aws.amazon.com/secretsmanager/latest/userguide/replicate-secrets.html) copies encrypted secret data and metadata, including resource policies, to replica regions. Configure `policy` on the primary regular or rotating secret; AWS propagates that policy to replicas automatically.
 
 ```hcl
 module "secrets-manager-replication" {
@@ -230,8 +230,7 @@ module "secrets-manager-replication" {
       description   = "Global configuration replicated across regions"
       secret_string = "global-configuration-data"
 
-      policy           = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy = true
+      policy = data.aws_iam_policy_document.secret_policy.json
 
       replica_regions = {
         "us-west-2" = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
@@ -242,11 +241,9 @@ module "secrets-manager-replication" {
 }
 ```
 
-Because the same policy document is applied in every region, use region-agnostic statements (e.g. `resources = ["*"]`, which scopes to the attached secret) rather than hardcoding the primary secret's ARN.
+Policy replication is asynchronous. AWS rejects direct resource-policy updates against replica secrets; update the primary secret policy instead. If a replica must diverge, promote it to a standalone secret first.
 
-> **Note**: Replication is asynchronous. On the very first apply that enables replication, a replica may still be provisioning when its policy is applied; if AWS returns `ResourceNotFoundException`, simply re-run `terraform apply`.
-
-> **Note**: Rotating secrets (`rotate_secrets`) now support `replica_regions` and `replicate_policy` using the same input shape as regular `secrets`. If you previously set `replica_regions` under `rotate_secrets`, upgrading to this version will begin managing those replicas instead of ignoring that attribute.
+> **Note**: Rotating secrets (`rotate_secrets`) support `replica_regions` using the same input shape as regular `secrets`. If you previously set `replica_regions` under `rotate_secrets`, version 1.2.0 and later manage those replicas instead of ignoring that attribute.
 
 ### Lifecycle Configuration
 
@@ -607,8 +604,6 @@ No modules.
 |------|------|
 | [aws_secretsmanager_secret.rsm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.sm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_policy.rsm-rp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
-| [aws_secretsmanager_secret_policy.sm-rp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
 | [aws_secretsmanager_secret_rotation.rsm-sr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation) | resource |
 | [aws_secretsmanager_secret_version.rsm-sv](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.rsm-svu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -626,8 +621,8 @@ No modules.
 | <a name="input_ephemeral"></a> [ephemeral](#input\_ephemeral) | Enable ephemeral resources and write-only arguments to prevent sensitive data from being stored in state. Requires Terraform >= 1.11. When enabled, secret values use write-only arguments (\_wo) and are not persisted to state. Example: true | `bool` | `false` | no |
 | <a name="input_existing_secrets"></a> [existing\_secrets](#input\_existing\_secrets) | Map of existing secret names or ARNs to import as data sources. Useful for referencing secrets created outside this module. Example: { existing\_secret = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret" } | `map(string)` | `{}` | no |
 | <a name="input_recovery_window_in_days"></a> [recovery\_window\_in\_days](#input\_recovery\_window\_in\_days) | Specifies the number of days that AWS Secrets Manager waits before it can delete the secret. This value can be 0 to force deletion without recovery or range from 7 to 30 days. Example: 7 | `number` | `30` | no |
-| <a name="input_rotate_secrets"></a> [rotate\_secrets](#input\_rotate\_secrets) | Map of secrets to keep and rotate in AWS Secrets Manager. Each secret must include rotation\_lambda\_arn. Set replica\_regions to replicate rotating secrets across regions, and set replicate\_policy (bool, default false) to apply the secret's resource policy to all replica\_regions on each apply. If replica\_regions was already set on older module versions, upgrading will begin managing those replicas. Example: { mysecret = { description = "My secret", secret\_string = "secret-value", rotation\_lambda\_arn = "arn:aws:lambda:us-east-1:123456789012:function:my-function" } } | `any` | `{}` | no |
-| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets to keep in AWS Secrets Manager. Set the optional per-secret attribute replicate\_policy (bool, default false) to apply the secret's resource policy to all of its replica\_regions on each apply. Example: { mysecret = { description = "My secret", secret\_string = "secret-value" } } | `any` | `{}` | no |
+| <a name="input_rotate_secrets"></a> [rotate\_secrets](#input\_rotate\_secrets) | Map of secrets to keep and rotate in AWS Secrets Manager. Each secret must include rotation\_lambda\_arn. Set replica\_regions to replicate rotating secrets across regions. AWS Secrets Manager replicates secret metadata, including resource policies, to replicas automatically. Example: { mysecret = { description = "My secret", secret\_string = "secret-value", rotation\_lambda\_arn = "arn:aws:lambda:us-east-1:123456789012:function:my-function" } } | `any` | `{}` | no |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets to keep in AWS Secrets Manager. Set replica\_regions to replicate secrets across regions. AWS Secrets Manager replicates secret metadata, including resource policies, to replicas automatically. Example: { mysecret = { description = "My secret", secret\_string = "secret-value" } } | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Key-value map of user-defined tags attached to the secret. Keys cannot start with 'aws:'. Example: { Environment = "prod", Owner = "team" } | `any` | `{}` | no |
 | <a name="input_unmanaged"></a> [unmanaged](#input\_unmanaged) | Terraform must ignore secrets lifecycle. Using this option you can initialize the secrets and rotate them outside Terraform, avoiding other users changing or rotating secrets by subsequent Terraform runs. Example: true | `bool` | `false` | no |
 | <a name="input_version_stages"></a> [version\_stages](#input\_version\_stages) | List of version stages to be handled. Valid values are 'AWSCURRENT' and 'AWSPENDING'. Kept as null for backwards compatibility. Example: ["AWSCURRENT"] | `list(string)` | `null` | no |
@@ -641,12 +636,10 @@ No modules.
 | <a name="output_existing_secrets"></a> [existing\_secrets](#output\_existing\_secrets) | Map of existing secrets referenced as data sources with their complete attributes. |
 | <a name="output_rotate_secret_arns"></a> [rotate\_secret\_arns](#output\_rotate\_secret\_arns) | Map of rotating secret names to their ARNs. Use these ARNs to grant permissions or reference rotating secrets in IAM policies and other AWS resources. |
 | <a name="output_rotate_secret_ids"></a> [rotate\_secret\_ids](#output\_rotate\_secret\_ids) | Map of rotating secret names to their resource IDs. Use these IDs to reference rotating secrets in other Terraform resources. |
-| <a name="output_rotate_secret_replica_policies"></a> [rotate\_secret\_replica\_policies](#output\_rotate\_secret\_replica\_policies) | Map of resource policies applied to rotating replica secrets, keyed by '<secret\_key>:<replica\_region>'. Only populated for rotating secrets with replicate\_policy enabled. |
 | <a name="output_rotate_secret_versions"></a> [rotate\_secret\_versions](#output\_rotate\_secret\_versions) | Map of managed rotating secret versions with their ARNs and version information. |
 | <a name="output_rotate_secrets"></a> [rotate\_secrets](#output\_rotate\_secrets) | Complete map of rotating secrets with all attributes including ARNs, names, KMS keys, descriptions, replica information, and rotation information. |
 | <a name="output_secret_arns"></a> [secret\_arns](#output\_secret\_arns) | Map of secret names to their ARNs. Use these ARNs to grant permissions or reference secrets in IAM policies and other AWS resources. |
 | <a name="output_secret_ids"></a> [secret\_ids](#output\_secret\_ids) | Map of secret names to their resource IDs. Use these IDs to reference secrets in other Terraform resources. |
-| <a name="output_secret_replica_policies"></a> [secret\_replica\_policies](#output\_secret\_replica\_policies) | Map of resource policies applied to replica secrets, keyed by '<secret\_key>:<replica\_region>'. Only populated for secrets with replicate\_policy enabled. |
 | <a name="output_secret_rotations"></a> [secret\_rotations](#output\_secret\_rotations) | Map of secret rotation configurations with Lambda ARN and rotation schedule information. |
 | <a name="output_secret_versions"></a> [secret\_versions](#output\_secret\_versions) | Map of managed secret versions with their ARNs and version information. |
 | <a name="output_secrets"></a> [secrets](#output\_secrets) | Complete map of regular secrets with all attributes including ARNs, names, KMS keys, descriptions, and replica information. |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AWS Secrets Manager helps you protect secrets needed to access your applications
 - ✅ **Cross-Region Replication**: Support for replicating secrets across AWS regions
 - ✅ **KMS Encryption**: Support for customer-managed KMS keys
 - ✅ **Resource Policies**: Attach custom IAM policies to secrets
-- ✅ **Replica Policy Propagation**: Optionally keep replica secrets' resource policies in sync with the primary
+- ✅ **Native Policy Replication**: AWS Secrets Manager replicates resource policies to replica regions automatically
 - ✅ **Flexible Secret Types**: Support for plain text, key/value pairs, and binary secrets
 
 ## Compatibility
@@ -244,6 +244,8 @@ module "secrets-manager-replication" {
 Policy replication is asynchronous. AWS rejects direct resource-policy updates against replica secrets; update the primary secret policy instead. If a replica must diverge, promote it to a standalone secret first.
 
 > **Note**: Rotating secrets (`rotate_secrets`) support `replica_regions` using the same input shape as regular `secrets`. If you previously set `replica_regions` under `rotate_secrets`, version 1.2.0 and later manage those replicas instead of ignoring that attribute.
+>
+> **Migration note for 1.2.0 users**: `replicate_policy`, `secret_replica_policies`, and `rotate_secret_replica_policies` have been removed because direct policy writes to replicas fail. Remove `replicate_policy = true` from module inputs and remove references to the removed outputs. If Terraform had already created any replica policy resources in state, the next apply will destroy them; this is expected because AWS manages replica policies from the primary secret.
 
 ### Lifecycle Configuration
 

--- a/examples/replication/README.md
+++ b/examples/replication/README.md
@@ -52,7 +52,7 @@ NOTE: If you leave the replica_regions with an empty map it will use the default
 
 # Replicating the resource policy
 
-AWS Secrets Manager replication copies the secret value to the replica regions, but **not** the resource policy. Set `replicate_policy = true` on a regular or rotating secret to have the module apply the primary secret's `policy` to every replica region, so policy updates on the source secret propagate to all replicas on the next apply.
+AWS Secrets Manager replication copies encrypted secret data and metadata, including resource policies, to replica regions. Configure `policy` on the primary regular or rotating secret; AWS propagates that policy to replicas automatically.
 
 ```
 data "aws_iam_policy_document" "secret_policy" {
@@ -76,11 +76,10 @@ module "secrets-manager-6" {
 
   secrets = {
     secret-with-policy = {
-      description             = "Secret whose resource policy is kept in sync on every replica"
+      description             = "Secret whose resource policy is replicated by AWS"
       recovery_window_in_days = 7
       secret_string           = "This is an example"
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:1234567890:key/12345678-1234-1234-1234-123456789012"
         us-east-2 = "arn:aws:kms:us-east-2:1234567890:key/12345678-1234-1234-1234-123456789012"
@@ -91,12 +90,11 @@ module "secrets-manager-6" {
 
   rotate_secrets = {
     rotating-secret-with-policy = {
-      description             = "Rotating secret whose resource policy is kept in sync on every replica"
+      description             = "Rotating secret whose resource policy is replicated by AWS"
       recovery_window_in_days = 7
       secret_string           = "This is a rotating example"
       rotation_lambda_arn     = "arn:aws:lambda:us-east-1:123456789012:function:lambda-rotate-secret"
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
         eu-west-1 = {
@@ -109,8 +107,6 @@ module "secrets-manager-6" {
 }
 ```
 
-NOTE: Because the same policy document is applied in every region, use region-agnostic statements (e.g. `resources = ["*"]`, which scopes to the attached secret) rather than hardcoding the primary secret's ARN.
+NOTE: Policy replication is asynchronous. AWS rejects direct resource-policy updates against replica secrets; update the primary secret policy instead. If a replica must diverge, promote it to a standalone secret first.
 
-NOTE: Replication is asynchronous. On the very first apply that enables replication, a replica may still be provisioning when its policy is applied; if AWS returns `ResourceNotFoundException`, simply re-run `terraform apply`.
-
-NOTE: Rotating secrets (`rotate_secrets`) support `replica_regions` and `replicate_policy` using the same input shape as regular `secrets`. If you previously set `replica_regions` under `rotate_secrets`, upgrading to this version will begin managing those replicas instead of ignoring that attribute.
+NOTE: Rotating secrets (`rotate_secrets`) support `replica_regions` using the same input shape as regular `secrets`. If you previously set `replica_regions` under `rotate_secrets`, version 1.2.0 and later manage those replicas instead of ignoring that attribute.

--- a/examples/replication/main.tf
+++ b/examples/replication/main.tf
@@ -9,8 +9,8 @@ terraform {
   }
 }
 
-# Resource policy applied to the primary secret and, via replicate_policy,
-# to every replica region as well.
+# Resource policy applied to the primary secret. AWS Secrets Manager
+# replicates resource policies to replica regions automatically.
 data "aws_iam_policy_document" "secret_policy" {
   statement {
     sid    = "AllowApplicationAccess"
@@ -57,11 +57,10 @@ module "secrets-manager-6" {
       recovery_window_in_days = 7
     },
     secret-with-policy = {
-      description             = "Secret whose resource policy is kept in sync on every replica"
+      description             = "Secret whose resource policy is replicated by AWS"
       recovery_window_in_days = 7
       secret_string           = "This is an example"
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:1234567890:key/12345678-1234-1234-1234-123456789012"
         us-east-2 = "arn:aws:kms:us-east-2:1234567890:key/12345678-1234-1234-1234-123456789012"
@@ -72,12 +71,11 @@ module "secrets-manager-6" {
 
   rotate_secrets = {
     rotating-secret-with-policy = {
-      description             = "Rotating secret whose resource policy is kept in sync on every replica"
+      description             = "Rotating secret whose resource policy is replicated by AWS"
       recovery_window_in_days = 7
       secret_string           = "This is a rotating example"
       rotation_lambda_arn     = "arn:aws:lambda:us-east-1:123456789012:function:lambda-rotate-secret"
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
         eu-west-1 = {

--- a/examples/rotation/README.md
+++ b/examples/rotation/README.md
@@ -1,7 +1,7 @@
 # Rotation example
 ```
-# Resource policy applied to the primary rotating secret and, via
-# replicate_policy, to every replica region as well.
+# Resource policy applied to the primary rotating secret. AWS Secrets Manager
+# replicates resource policies to replica regions automatically.
 data "aws_iam_policy_document" "secret_policy" {
   statement {
     sid    = "AllowApplicationAccess"
@@ -35,7 +35,6 @@ module "secrets-manager-4" {
       rotation_lambda_arn     = "arn:aws:lambda:us-east-1:123455678910:function:lambda-rotate-secret"
       recovery_window_in_days = 7
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
         eu-west-1 = {
@@ -55,7 +54,7 @@ module "secrets-manager-4" {
 }
 ```
 
-Rotating secrets support `replica_regions` and `replicate_policy` using the same input shape as regular `secrets`. Because the same policy document is applied in every region, use region-agnostic statements such as `resources = ["*"]` instead of hardcoding the primary secret ARN. If you previously set `replica_regions` under `rotate_secrets`, upgrading to this version will begin managing those replicas instead of ignoring that attribute.
+Rotating secrets support `replica_regions` using the same input shape as regular `secrets`. AWS Secrets Manager replicates resource policies to replica regions automatically and rejects direct resource-policy updates against replica secrets; update the primary secret policy instead. If you previously set `replica_regions` under `rotate_secrets`, version 1.2.0 and later manage those replicas instead of ignoring that attribute.
 
 # Lambda to rotate secrets
 

--- a/examples/rotation/main.tf
+++ b/examples/rotation/main.tf
@@ -9,8 +9,8 @@ terraform {
   }
 }
 
-# Resource policy applied to the primary rotating secret and, via
-# replicate_policy, to every replica region as well.
+# Resource policy applied to the primary rotating secret. AWS Secrets Manager
+# replicates resource policies to replica regions automatically.
 data "aws_iam_policy_document" "secret_policy" {
   statement {
     sid    = "AllowApplicationAccess"
@@ -44,7 +44,6 @@ module "secrets-manager-4" {
       rotation_lambda_arn     = "arn:aws:lambda:us-east-1:123455678910:function:lambda-rotate-secret"
       recovery_window_in_days = 7
       policy                  = data.aws_iam_policy_document.secret_policy.json
-      replicate_policy        = true
       replica_regions = {
         us-west-2 = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
         eu-west-1 = {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ locals {
       recovery_window_in_days        = lookup(v, "recovery_window_in_days", var.recovery_window_in_days)
       tags                           = lookup(v, "tags", null)
       replica_regions                = lookup(v, "replica_regions", {})
-      replicate_policy               = lookup(v, "replicate_policy", false)
       secret_string                  = lookup(v, "secret_string", null)
       secret_key_value               = lookup(v, "secret_key_value", null)
       secret_binary                  = lookup(v, "secret_binary", null)
@@ -34,7 +33,6 @@ locals {
       recovery_window_in_days        = lookup(v, "recovery_window_in_days", var.recovery_window_in_days)
       tags                           = lookup(v, "tags", null)
       replica_regions                = lookup(v, "replica_regions", {})
-      replicate_policy               = lookup(v, "replicate_policy", false)
       secret_string                  = lookup(v, "secret_string", null)
       secret_key_value               = lookup(v, "secret_key_value", null)
       secret_binary                  = lookup(v, "secret_binary", null)
@@ -75,37 +73,6 @@ locals {
     }
   }
 
-  # Secrets Manager replication copies the secret value but not the resource
-  # policy, so replicas need the policy applied explicitly in their own region.
-  # Flatten (secret, replica region) pairs for secrets that opt in via
-  # replicate_policy. The filter must only use plan-time literals: gating on
-  # v.policy here would make the whole for_each unknown when the policy is
-  # computed from same-apply resources (policy presence is enforced by a
-  # precondition on the resource instead).
-  secret_replica_policies = merge([
-    for k, v in local.secrets_config : {
-      for region in distinct([for rk, rv in v.replica_regions : try(rv.region, rk)]) :
-      "${k}:${region}" => {
-        secret_key = k
-        region     = region
-      }
-    }
-    if v.replicate_policy
-  ]...)
-
-  # Same replica policy propagation shape for rotating secrets. Keep this as a
-  # separate local/resource/output from regular secrets so existing
-  # secret_replica_policies output keys remain backward-compatible.
-  rotate_secret_replica_policies = merge([
-    for k, v in local.rotate_secrets_config : {
-      for region in distinct([for rk, rv in v.replica_regions : try(rv.region, rk)]) :
-      "${k}:${region}" => {
-        secret_key = k
-        region     = region
-      }
-    }
-    if v.replicate_policy
-  ]...)
 }
 
 resource "aws_secretsmanager_secret" "sm" {
@@ -124,27 +91,6 @@ resource "aws_secretsmanager_secret" "sm" {
     content {
       region     = try(replica.value.region, replica.key)
       kms_key_id = try(replica.value.kms_key_id, can(tostring(replica.value)) ? tostring(replica.value) : null)
-    }
-  }
-}
-
-resource "aws_secretsmanager_secret_policy" "sm-rp" {
-  for_each = local.secret_replica_policies
-
-  # A replica secret shares the primary secret's ARN except for the region
-  # component (arn:partition:secretsmanager:region:account:secret:name-suffix),
-  # so the replica ARN can be derived by swapping in the replica region.
-  region = each.value.region
-  secret_arn = join(":", [
-    for i, part in split(":", aws_secretsmanager_secret.sm[each.value.secret_key].arn) :
-    i == 3 ? each.value.region : part
-  ])
-  policy = local.secrets_config[each.value.secret_key].policy
-
-  lifecycle {
-    precondition {
-      condition     = local.secrets_config[each.value.secret_key].policy != null
-      error_message = "Secret \"${each.value.secret_key}\" sets replicate_policy = true but does not define a policy."
     }
   }
 }
@@ -209,27 +155,6 @@ resource "aws_secretsmanager_secret" "rsm" {
     content {
       region     = try(replica.value.region, replica.key)
       kms_key_id = try(replica.value.kms_key_id, can(tostring(replica.value)) ? tostring(replica.value) : null)
-    }
-  }
-}
-
-resource "aws_secretsmanager_secret_policy" "rsm-rp" {
-  for_each = local.rotate_secret_replica_policies
-
-  # A replica secret shares the primary secret's ARN except for the region
-  # component (arn:partition:secretsmanager:region:account:secret:name-suffix),
-  # so the replica ARN can be derived by swapping in the replica region.
-  region = each.value.region
-  secret_arn = join(":", [
-    for i, part in split(":", aws_secretsmanager_secret.rsm[each.value.secret_key].arn) :
-    i == 3 ? each.value.region : part
-  ])
-  policy = local.rotate_secrets_config[each.value.secret_key].policy
-
-  lifecycle {
-    precondition {
-      condition     = local.rotate_secrets_config[each.value.secret_key].policy != null
-      error_message = "Rotating secret \"${each.value.secret_key}\" sets replicate_policy = true but does not define a policy."
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,24 +107,6 @@ output "secrets_by_name" {
   )
 }
 
-# Replica policy outputs
-output "secret_replica_policies" {
-  description = "Map of resource policies applied to replica secrets, keyed by '<secret_key>:<replica_region>'. Only populated for secrets with replicate_policy enabled."
-  value = { for k, v in aws_secretsmanager_secret_policy.sm-rp : k => {
-    id         = v.id
-    secret_arn = v.secret_arn
-    region     = v.region
-  } }
-}
-
-output "rotate_secret_replica_policies" {
-  description = "Map of resource policies applied to rotating replica secrets, keyed by '<secret_key>:<replica_region>'. Only populated for rotating secrets with replicate_policy enabled."
-  value = { for k, v in aws_secretsmanager_secret_policy.rsm-rp : k => {
-    id         = v.id
-    secret_arn = v.secret_arn
-    region     = v.region
-  } }
-}
 
 # Data source outputs for existing secrets
 output "existing_secrets" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,7 +107,6 @@ output "secrets_by_name" {
   )
 }
 
-
 # Data source outputs for existing secrets
 output "existing_secrets" {
   description = "Map of existing secrets referenced as data sources with their complete attributes."

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "ephemeral" {
 
 # Secrets with rotation
 variable "rotate_secrets" {
-  description = "Map of secrets to keep and rotate in AWS Secrets Manager. Each secret must include rotation_lambda_arn. Set replica_regions to replicate rotating secrets across regions, and set replicate_policy (bool, default false) to apply the secret's resource policy to all replica_regions on each apply. If replica_regions was already set on older module versions, upgrading will begin managing those replicas. Example: { mysecret = { description = \"My secret\", secret_string = \"secret-value\", rotation_lambda_arn = \"arn:aws:lambda:us-east-1:123456789012:function:my-function\" } }"
+  description = "Map of secrets to keep and rotate in AWS Secrets Manager. Each secret must include rotation_lambda_arn. Set replica_regions to replicate rotating secrets across regions. AWS Secrets Manager replicates secret metadata, including resource policies, to replicas automatically. Example: { mysecret = { description = \"My secret\", secret_string = \"secret-value\", rotation_lambda_arn = \"arn:aws:lambda:us-east-1:123456789012:function:my-function\" } }"
   type        = any
   default     = {}
 
@@ -81,7 +81,7 @@ variable "rotate_secrets" {
 
 # Regular secrets (non-rotating)
 variable "secrets" {
-  description = "Map of secrets to keep in AWS Secrets Manager. Set the optional per-secret attribute replicate_policy (bool, default false) to apply the secret's resource policy to all of its replica_regions on each apply. Example: { mysecret = { description = \"My secret\", secret_string = \"secret-value\" } }"
+  description = "Map of secrets to keep in AWS Secrets Manager. Set replica_regions to replicate secrets across regions. AWS Secrets Manager replicates secret metadata, including resource policies, to replicas automatically. Example: { mysecret = { description = \"My secret\", secret_string = \"secret-value\" } }"
   type        = any
   default     = {}
 


### PR DESCRIPTION
## Summary
- Reverts the broken `replicate_policy` implementation added for replica secret policies.
- Removes replica policy resources and outputs so Terraform no longer calls `PutResourcePolicy` against replica secrets.
- Keeps `replica_regions` support for rotating secrets, and updates docs/examples to explain that AWS Secrets Manager replicates resource policies from the primary secret natively.

## Source-backed behavior
AWS Secrets Manager docs state that replication copies encrypted secret data and metadata, including resource policies, to replica Regions. Replica secrets should not receive independent resource policy writes; update the primary secret policy instead.

## Test Plan
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `terraform -chdir=examples/replication init -backend=false`
- `terraform -chdir=examples/replication validate`
- `terraform -chdir=examples/rotation init -backend=false`
- `terraform -chdir=examples/rotation validate`
- `pre-commit run --files main.tf variables.tf outputs.tf README.md examples/replication/main.tf examples/replication/README.md examples/rotation/main.tf examples/rotation/README.md`
- `terraform fmt -check -recursive`
- `git diff --check`

Closes #188
