### PR TITLE
chore: use shared Renovate config for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard"
+    "github>lgallard/renovate-config"
   ],
   "major": {
     "dependencyDashboardApproval": true
@@ -43,13 +42,19 @@
       ]
     },
     {
-      "matchDatasources": ["golang-version"],
+      "matchDatasources": [
+        "golang-version"
+      ],
       "ignoreUnstable": true,
       "enabled": true
     },
     {
-      "matchDepTypes": ["action"],
-      "matchPackageNames": ["actions/setup-go"],
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchPackageNames": [
+        "actions/setup-go"
+      ],
       "extractVersion": "^v(?<version>.*)$",
       "versioning": "go-mod-directive",
       "ignoreUnstable": true


### PR DESCRIPTION
## Summary
- Extend the shared `github>lgallard/renovate-config` preset
- Keep existing repo-specific Renovate rules in place
- Ensure GitHub Actions workflow files are covered where the repo had restricted `includePaths`

## Why
This centralizes the recurring GitHub Actions update policy:
- weekly grouped GitHub Actions updates
- Anthropic/codebot actions separated for review
- major updates gated through the Dependency Dashboard
- Terraform provider/module updates remain non-automerge

## Validation
- `python3 -m json.tool renovate.json`
- `pnpm dlx --package renovate renovate-config-validator renovate.json`
